### PR TITLE
Fix airdrop dates. Setting first step at 18.01.2023

### DIFF
--- a/protocols/ipor.ts
+++ b/protocols/ipor.ts
@@ -12,8 +12,8 @@ const ipor: Protocol = {
     "Core Team": manualLinear(TGE + periodToSeconds.day, TGE + periodToSeconds.day + periodToSeconds.year * 3, 20e6),
     "Investors": manualLinear(TGE + periodToSeconds.day, TGE + periodToSeconds.day + periodToSeconds.year * 3, 11.85e6),
     "airdrop": [
-        manualStep(TGE + periodToSeconds.year + 17 * periodToSeconds.day, periodToSeconds.day, 1, 85200),
-        manualLinear(TGE + periodToSeconds.year + 17 * periodToSeconds.day, TGE + periodToSeconds.year + 17 * periodToSeconds.day + periodToSeconds.month * 6, 305000),
+        manualStep(TGE + periodToSeconds.month + 17 * periodToSeconds.day, periodToSeconds.day, 0, 85200),
+        manualLinear(TGE + periodToSeconds.month + 17 * periodToSeconds.day, TGE + periodToSeconds.month + 17 * periodToSeconds.day + periodToSeconds.month * 6, 305000),
     ],
     meta: {
         notes: [


### PR DESCRIPTION
Fixed to match docs: https://docs.ipor.io/tokenomics/token-distribution-model