### PR TITLE
Add PulseChain and PulseX protocols

### DIFF
--- a/protocols/pulsechain.ts
+++ b/protocols/pulsechain.ts
@@ -1,0 +1,29 @@
+import { manualCliff } from "../adapters/manual";
+import { Protocol } from "../types/adapters";
+
+const start = 1683937680; // 2023-05-12
+const total = 135e12;
+
+const pulsechain: Protocol = {
+  "Public Sacrifice": manualCliff(
+    start,
+    total * 0.1185185185,
+  ),
+  "Origin Address": manualCliff(
+    start,
+    total * 0.8814814815,
+  ),
+  meta: {
+    token: `coingecko:pulsechain`,
+    notes: [
+      `Public Sacrifice schedule has been estimated based on the information in the source material.`,
+    ],
+    sources: [`https://t.me/PulseChainCom`],
+    protocolIds: ["5374"],
+  },
+  categories: {
+    noncirculating: ["Origin Address"],
+    publicSale: ["Public Sacrifice"],
+  },
+};
+export default pulsechain;

--- a/protocols/pulsex.ts
+++ b/protocols/pulsex.ts
@@ -1,0 +1,29 @@
+import { manualCliff } from "../adapters/manual";
+import { Protocol } from "../types/adapters";
+
+const start = 1683937680; // 2023-05-12
+const total = 142e12;
+
+const pulsex: Protocol = {
+  "Public Sacrifice": manualCliff(
+    start,
+    total * 0.1408450704,
+  ),
+  "Origin Address": manualCliff(
+    start,
+    total * 0.8591549296,
+  ),
+  meta: {
+    token: `coingecko:pulsex`,
+    notes: [
+      `Public Sacrifice schedule has been estimated based on the information in the source material.`,
+    ],
+    sources: [`https://t.me/PulseChainCom`],
+    protocolIds: ["2995"],
+  },
+  categories: {
+    noncirculating: ["Origin Address"],
+    publicSale: ["Public Sacrifice"],
+  },
+};
+export default pulsex;


### PR DESCRIPTION
## Changes Overview

These changes introduce two new protocol files: `pulsechain.ts` and `pulsex.ts`. Both files define token distribution details for their respective protocols.

## Reason for Changes

The addition of these files expands the coverage of the project to include PulseChain and PulseX, likely to track and analyze their token distributions.

## Detailed Description

1. **PulseChain Protocol**
   - Defines a total initial supply of 135 trillion tokens.
   - Allocates 11.8% to "Public Sacrifice".
   - Allocates 88.1% to "Origin Address".

2. **PulseX Protocol**
   - Defines a total supply of 142 trillion tokens.
   - Allocates 14.1% to "Public Sacrifice".
   - Allocates 85.9% to "Origin Address".

3. **Common Features**
   - Both use the `manualCliff` function for token allocation.
   - Both have a start timestamp of 1683937680 (May 12, 2023) https://x.com/RichardHeartWin/status/1657180980640194562
   - Both include metadata such as token identifier, notes, sources, and protocol IDs.
   - Both define categories for non-circulating and public sale tokens.