### PR TITLE
add pancakeswap and shadow

### DIFF
--- a/adapters/pancakeswap/abi.ts
+++ b/adapters/pancakeswap/abi.ts
@@ -1,0 +1,87 @@
+const abi = {
+    cakeRateToRegularFarm: {
+        inputs: [],
+        name: "cakeRateToRegularFarm",
+        outputs: [{ name: "", type: "uint256" }],
+        stateMutability: "view",
+        type: "function"
+    },
+    cakeRateToSpecialFarm: {
+        inputs: [],
+        name: "cakeRateToSpecialFarm",
+        outputs: [{ name: "", type: "uint256" }],
+        stateMutability: "view",
+        type: "function"
+    },
+    MASTERCHEF_CAKE_PER_BLOCK: {
+        inputs: [],
+        name: "MASTERCHEF_CAKE_PER_BLOCK",
+        outputs: [{ name: "", type: "uint256" }],
+        stateMutability: "view",
+        type: "function"
+    },
+    CAKE_RATE_TOTAL_PRECISION: {
+        inputs: [],
+        name: "CAKE_RATE_TOTAL_PRECISION",
+        outputs: [{ name: "", type: "uint256" }],
+        stateMutability: "view",
+        type: "function"
+    },
+    poolLength: {
+        inputs: [],
+        name: "poolLength",
+        outputs: [{ internalType: "uint256", name: "", type: "uint256" }],
+        stateMutability: "view",
+        type: "function"
+    },
+    cakePerBlock: {
+        inputs: [{ name: "_isRegular", type: "bool" }],
+        name: "cakePerBlock",
+        outputs: [{ name: "amount", type: "uint256" }],
+        stateMutability: "view",
+        type: "function"
+    },
+    totalRegularAllocPoint: {
+        inputs: [],
+        name: "totalRegularAllocPoint",
+        outputs: [{ name: "", type: "uint256" }],
+        stateMutability: "view",
+        type: "function"
+    },
+    totalSpecialAllocPoint: {
+        inputs: [],
+        name: "totalSpecialAllocPoint",
+        outputs: [{ name: "", type: "uint256" }],
+        stateMutability: "view",
+        type: "function"
+    },
+    // Pool info
+    poolInfo: {
+        inputs: [{ name: "", type: "uint256" }],
+        name: "poolInfo",
+        outputs: [
+            { name: "accCakePerShare", type: "uint256" },
+            { name: "lastRewardBlock", type: "uint256" },
+            { name: "allocPoint", type: "uint256" },
+            { name: "totalBoostedShare", type: "uint256" },
+            { name: "isRegular", type: "bool" }
+        ],
+        stateMutability: "view",
+        type: "function"
+    },
+    lpToken: {
+        inputs: [{ name: "", type: "uint256" }],
+        name: "lpToken",
+        outputs: [{ name: "", type: "address" }],
+        stateMutability: "view",
+        type: "function"
+    }
+};
+
+const CONSTANTS = {
+    MASTERCHEF_CAKE_PER_BLOCK: "40000000000000000000", // 40 CAKE per block
+    CAKE_RATE_TOTAL_PRECISION: "1000000000000"
+};
+
+export default abi;
+export { CONSTANTS };

--- a/adapters/pancakeswap/index.ts
+++ b/adapters/pancakeswap/index.ts
@@ -1,0 +1,6 @@
+import adapter from "./masterchef";
+
+const MASTERCHEF_V2 = "0xa5f8C5Dbd5F286960b9d90548680aE5ebFf07652";
+
+export const pancakeRegular = adapter(MASTERCHEF_V2, "bsc", true);
+export const pancakeSpecial = adapter(MASTERCHEF_V2, "bsc", false);

--- a/adapters/pancakeswap/masterchef.ts
+++ b/adapters/pancakeswap/masterchef.ts
@@ -1,0 +1,111 @@
+import { call, multiCall } from "@defillama/sdk/build/abi/abi2";
+import { AdapterResult } from "../../types/adapters";
+import abi, { CONSTANTS } from "./abi";
+
+const BLOCKS_PER_DAY = 28800; // approximate number of blocks per day (assuming 3s block time)
+const ONE_YEAR = 365 * 24 * 60 * 60;
+const DECIMALS = 18;
+const CAKE_TOKEN = "0x0E09FaBB73Bd3Ade0a17ECC321fD13a19e81cE82";
+
+export default function adapter(target: string, chain: string, isRegular: boolean) {
+    return async function calculateEmissions(): Promise<AdapterResult[]> {
+        try {
+            const poolLength = await call({
+                target,
+                abi: abi.poolLength,
+                chain,
+            });
+
+            const [cakeRateToRegularFarm, cakeRateToSpecialFarm, masterPerBlock, ratePrecision, totalAlloc] = await Promise.all([
+                call({
+                    target,
+                    abi: abi.cakeRateToRegularFarm,
+                    chain,
+                }),
+                call({
+                    target,
+                    abi: abi.cakeRateToSpecialFarm,
+                    chain,
+                }),
+                call({
+                    target,
+                    abi: abi.MASTERCHEF_CAKE_PER_BLOCK,
+                    chain,
+                }).catch(() => CONSTANTS.MASTERCHEF_CAKE_PER_BLOCK),
+                call({
+                    target,
+                    abi: abi.CAKE_RATE_TOTAL_PRECISION,
+                    chain,
+                }).catch(() => CONSTANTS.CAKE_RATE_TOTAL_PRECISION),
+                call({
+                    target,
+                    abi: isRegular ? abi.totalRegularAllocPoint : abi.totalSpecialAllocPoint,
+                    chain,
+                }),
+            ]);
+
+            const netEmissionRate = BigInt(masterPerBlock) * 
+                                  BigInt(isRegular ? cakeRateToRegularFarm : cakeRateToSpecialFarm) / 
+                                  BigInt(ratePrecision);
+
+            const poolIndexes = Array.from({ length: Number(poolLength) }, (_, i) => i);
+            
+            const [poolInfos, lpTokens] = await Promise.all([
+                multiCall({
+                    calls: poolIndexes.map(pid => ({
+                        target,
+                        params: [pid],
+                    })),
+                    abi: abi.poolInfo,
+                    chain,
+                    permitFailure: true,
+                }),
+                multiCall({
+                    calls: poolIndexes.map(pid => ({
+                        target,
+                        params: [pid],
+                    })),
+                    abi: abi.lpToken,
+                    chain,
+                    permitFailure: true,
+                }),
+            ]);
+
+            const results: AdapterResult[] = [];
+            const now = Math.floor(Date.now() / 1000);
+
+            for (let pid = 0; pid < poolLength; pid++) {
+                const poolInfo = poolInfos[pid];
+                const lpToken = lpTokens[pid];
+
+                if (!poolInfo || !lpToken) continue;
+                if (poolInfo.allocPoint === "0") continue;
+                if (poolInfo.isRegular !== isRegular) continue;
+
+                if (BigInt(totalAlloc) === BigInt(0)) continue;
+
+                const poolEmissionWei = BigInt(poolInfo.allocPoint) * 
+                                      BigInt(BLOCKS_PER_DAY) * 
+                                      netEmissionRate / 
+                                      BigInt(totalAlloc);
+
+                const dailyEmission = Number(poolEmissionWei) / (10 ** DECIMALS);
+                const yearlyEmission = dailyEmission * 365;
+
+                results.push({
+                    type: "linear",
+                    start: now,
+                    end: now + ONE_YEAR,
+                    amount: yearlyEmission,
+                    receiver: lpToken,
+                    token: CAKE_TOKEN
+                });
+            }
+
+            return results;
+
+        } catch (error) {
+            throw new Error(`Failed to fetch PancakeSwap ${isRegular ? "regular" : "special"} emissions: ${error}`);
+        }
+    };
+}

--- a/protocols/pancakeswap.ts
+++ b/protocols/pancakeswap.ts
@@ -1,0 +1,24 @@
+import { Protocol } from "../types/adapters";
+import { pancakeRegular, pancakeSpecial } from "../adapters/pancakeswap";
+
+const pancakeswap: Protocol = {
+    "Regular Farming": pancakeRegular,
+    "Special Ecosystem": pancakeSpecial,
+    meta: {
+        sources: [
+            "https://docs.pancakeswap.finance/protocol/cake-tokenomics",
+            "https://docs.pancakeswap.finance/welcome-to-pancakeswap/how-to-guides/v3-v2-migration/migration/masterchef-v2"
+        ],
+        token: `bsc:0x0E09FaBB73Bd3Ade0a17ECC321fD13a19e81cE82`,
+        protocolIds: ["parent#pancakeswap"],
+        notes: [
+            "In addition to emissions above, PancakeSwap also mint CAKE to dev address at rate of 9.09%, however it's burned weekly and never enters circulation. Therefore it's not included in this analysis.",
+        ]
+    },
+    categories: {
+        farming: ["Regular Farming"],
+        noncirculating: ["Special Ecosystem"]
+    },
+};
+
+export default pancakeswap;

--- a/protocols/shadow.ts
+++ b/protocols/shadow.ts
@@ -1,0 +1,108 @@
+import { manualCliff, manualLinear } from "../adapters/manual";
+import { LinearAdapterResult, Protocol } from "../types/adapters";
+import { periodToSeconds } from "../utils/time";
+
+const start = 1736899200; 
+const total = 10_000_000;
+
+const emissions = (percentage: number): LinearAdapterResult[] => {
+  const result: LinearAdapterResult[] = [];
+  let weeklyEmissionRate = 50_000; // starting emission rate (50k SHADOW per week)
+  let weekNumber = 0;
+  let totalEmitted = 3_000_000;
+
+  // Note: Elastic emissions (±25% multiplier change) are not modeled here.
+  // This function models the base decay schedule assuming a constant 1% decay (multiplier=9900).
+  while (totalEmitted < total) {
+    let currentWeekEmissionAmount = (weeklyEmissionRate * percentage) / 100;
+    let isFinalEmission = false;
+
+    if (totalEmitted + currentWeekEmissionAmount > total) {
+      currentWeekEmissionAmount = (total - totalEmitted);
+      currentWeekEmissionAmount = (currentWeekEmissionAmount * percentage) / 100;
+
+      isFinalEmission = true;
+    }
+
+    result.push({
+      type: "linear",
+      start: start + periodToSeconds.weeks(weekNumber),
+      end: start + periodToSeconds.weeks(weekNumber + 1),
+      amount: currentWeekEmissionAmount
+    });
+
+    totalEmitted += currentWeekEmissionAmount;
+
+    if (isFinalEmission) {
+      break;
+    }
+
+    weeklyEmissionRate *= 0.99; // apply 1% decay for the next period's calculation base
+
+    weekNumber++;
+    if (weeklyEmissionRate < 1) break;
+  }
+
+  return result;
+}
+
+const shadow: Protocol = {
+  // Direct SHADOW allocations (no vesting)
+  "Protocol-Owned Liquidity": manualCliff(start, total * 0.03),  // 300,000
+  "Reserves": manualCliff(start, total * 0.045),         // 450,000
+
+  // xSHADOW allocations (with 180-day vesting)
+  "Contributors": manualLinear(
+    start,
+    start + periodToSeconds.days(180),
+    total * 0.075,
+  ),
+  "Presales": manualLinear(
+    start,
+    start + periodToSeconds.days(180),
+    total * 0.075,
+  ),
+  "Airdrop": manualLinear(
+    start,
+    start + periodToSeconds.days(180),
+    total * 0.03,
+  ),
+  "Partners": manualLinear(
+    start,
+    start + periodToSeconds.days(180),
+    total * 0.03,
+  ),
+  "Community Incentives": manualLinear(
+    start,
+    start + periodToSeconds.days(180),
+    total * 0.015,
+  ),
+
+  // Emissions (remaining 7M)
+  "Gauge Emissions": emissions(100),
+
+  meta: {
+    notes: [
+      "We assume the initial allocations are linearly vested over 180 days.",
+      "All allocations except Protocol-Owned Liquidity and Reserves are locked in xSHADOW.",
+      "The emissions are elastic and depend on the protocol's revenue, which is not modeled here.",
+    ],
+    token: `sonic:0x3333b97138d4b086720b5ae8a7844b1345a33333`,
+    sources: [
+      "https://docs.shadow.so/pages/tokenomics",
+      "https://docs.shadow.so/pages/xshadow",
+      "https://sonicscan.org/tx/0xdbd2344dfd88f549599bb17a01e86263592da6c034d4a8541d824832ba375d86"
+    ],
+    protocolIds: ["parent#shadow-exchange"]
+  },
+  categories: {
+    insiders: ["Contributors", "Partners"],
+    publicSale: ["Presales"],
+    airdrop: ["Airdrop"],
+    noncirculating: ["Reserves"],
+    farming: ["Gauge Emissions"],
+    liquidity: ["Protocol-Owned Liquidity"]
+  }
+};
+
+export default shadow;


### PR DESCRIPTION
add pancakeswap and shadow
pancakeswap probably will need to fill data manually first

shadow vesting data isn't available the emission model are based on this tx https://sonicscan.org/tx/0xdbd2344dfd88f549599bb17a01e86263592da6c034d4a8541d824832ba375d86 that sets the initial weekly emission to 50000 SHADOW