### PR TITLE
Fix/convex

### DIFF
--- a/protocols/convex.ts
+++ b/protocols/convex.ts
@@ -1,52 +1,111 @@
 import { manualCliff, manualLinear } from "../adapters/manual";
-import { supply, latest } from "../adapters/supply";
+import { supply } from "../adapters/supply";
 import { CliffAdapterResult, Protocol } from "../types/adapters";
-import { queryAggregatedDailyLogsAmounts } from "../utils/queries";
+import { queryCustom } from "../utils/queries";
 import { periodToSeconds, readableToSeconds } from "../utils/time";
 
 const deployTime = 1621292400;
 const chain: any = "ethereum";
 const CVX: string = "0x4e3fbd56cd56c3e72c1403e103b45db9da5b9d2b";
+const TREASURY_ADDRESS = "0x1389388d01708118b497f59521f6943be2541bb7";
+const EXCLUDED_TO_ADDRESS = "0x5f465e9fcffc217c5849906216581a657cd60605";
 
 const rewards = async (): Promise<CliffAdapterResult[]> => {
   const result: CliffAdapterResult[] = [];
-  const data = await queryAggregatedDailyLogsAmounts({
-    address: "0xcf50b810e57ac33b91dcf525c6ddd9881b139332",
-    topic0: "0xe2403640ba68fed3a2f88b7557551d1993f84b99bb10ff833f0cf8db0c5e0486",
-    startDate: "2021-05-17",
-  })
 
-  for (let i = 0; i < data.length; i++) {
+  // 1. Get RewardPaid events from emissions contract, excluding those going to treasury
+  const rewardPaidSql = `
+    SELECT
+      toStartOfDay(timestamp) AS date,
+      SUM(reinterpretAsUInt256(reverse(unhex(substring(data, 3))))) AS amount
+    FROM evm_indexer.logs
+    WHERE address = {rewardContract:String}
+      AND topic0 = {rewardTopic:String}
+      AND topic1 != {treasuryTopic:String}
+      AND timestamp >= toDateTime({startDate:String})
+    GROUP BY date
+    ORDER BY date ASC
+  `;
+
+  const rewardPaidData = await queryCustom(rewardPaidSql, {
+    rewardContract: "0x449f2fd99174e1785CF2A1c79E665Fec3dD1DdC6",
+    rewardTopic: "0xe2403640ba68fed3a2f88b7557551d1993f84b99bb10ff833f0cf8db0c5e0486",
+    treasuryTopic: `0x000000000000000000000000${TREASURY_ADDRESS.substring(2).toLowerCase()}`,
+    startDate: "2021-05-17"
+  });
+
+  // 2. Get treasury expenses (CVX transfers from treasury, excluding Masterchef (which flows back to treasury)
+  const treasuryExpensesSql = `
+    SELECT
+      toStartOfDay(timestamp) AS date,
+      SUM(reinterpretAsUInt256(reverse(unhex(substring(data, 3))))) AS amount
+    FROM evm_indexer.logs
+    WHERE address = {cvxToken:String}
+      AND topic0 = '0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef'
+      AND topic1 = {treasuryFromTopic:String}
+      AND topic2 != {excludedToTopic:String}
+      AND timestamp >= toDateTime({startDate:String})
+    GROUP BY date
+    ORDER BY date ASC
+  `;
+
+  const treasuryExpensesData = await queryCustom(treasuryExpensesSql, {
+    cvxToken: CVX,
+    treasuryFromTopic: `0x000000000000000000000000${TREASURY_ADDRESS.substring(2).toLowerCase()}`,
+    excludedToTopic: `0x000000000000000000000000${EXCLUDED_TO_ADDRESS.substring(2).toLowerCase()}`,
+    startDate: "2021-05-17"
+  });
+
+  const combinedData = new Map<string, number>();
+
+  // Add reward paid amounts
+  for (const item of rewardPaidData) {
+    const dateKey = item.date;
+    const amount = Number(item.amount) / 1e18;
+    combinedData.set(dateKey, (combinedData.get(dateKey) || 0) + amount);
+  }
+
+  // Add treasury expenses
+  for (const item of treasuryExpensesData) {
+    const dateKey = item.date;
+    const amount = Number(item.amount) / 1e18;
+    combinedData.set(dateKey, (combinedData.get(dateKey) || 0) + amount);
+  }
+
+  for (const [date, amount] of combinedData.entries()) {
     result.push({
       type: "cliff",
-      start: readableToSeconds(data[i].date),
-      amount: Number(data[i].amount) / 1e18,
+      start: readableToSeconds(date),
+      amount: amount,
     });
   }
+
+  result.sort((a, b) => a.start - b.start);
+
   return result;
 }
 
 const convex: Protocol = {
   Investors: manualLinear(
-    deployTime,
-    deployTime + periodToSeconds.year,
-    3300000,
+      deployTime,
+      deployTime + periodToSeconds.year,
+      3300000,
   ),
   Treasury: manualLinear(
-    deployTime,
-    deployTime + periodToSeconds.year,
-    9700000,
+      deployTime,
+      deployTime + periodToSeconds.year,
+      9700000,
   ),
   Team: manualLinear(deployTime, deployTime + periodToSeconds.year, 10000000),
   "veCRV voters": manualCliff(deployTime, 1000000),
   "veCRV holders": manualCliff(deployTime, 1000000),
   "Liquidity mining": manualLinear(
-    deployTime,
-    deployTime + 4 * periodToSeconds.year,
-    25000000,
+      deployTime,
+      deployTime + 4 * periodToSeconds.year,
+      25000000,
   ),
   "Curve LP rewards": () =>
-    supply(chain, CVX, deployTime, "convex-finance", 50000000),
+      supply(chain, CVX, deployTime, "convex-finance", 50000000),
   "Incentives": rewards,
   meta: {
     sources: [
@@ -71,4 +130,5 @@ const convex: Protocol = {
     insiders: ["Team"],
   },
 };
+
 export default convex;

--- a/protocols/convex.ts
+++ b/protocols/convex.ts
@@ -28,7 +28,7 @@ const rewards = async (): Promise<CliffAdapterResult[]> => {
   `;
 
   const rewardPaidData = await queryCustom(rewardPaidSql, {
-    rewardContract: "0x449f2fd99174e1785CF2A1c79E665Fec3dD1DdC6",
+    rewardContract: "0x449f2fd99174e1785cf2a1c79e665fec3dd1ddc6",
     rewardTopic: "0xe2403640ba68fed3a2f88b7557551d1993f84b99bb10ff833f0cf8db0c5e0486",
     treasuryTopic: `0x000000000000000000000000${TREASURY_ADDRESS.substring(2).toLowerCase()}`,
     startDate: "2021-05-17"


### PR DESCRIPTION
The current adapter for Convex uses the wrong contract and token.
It's currently tracking emissions on the Convex staking contract at 0xcf50b810e57ac33b91dcf525c6ddd9881b139332 which are paid in CRV from protocol revenue, not CVX.
The PR fixes it by:
- Tracking the actual emission contract at 0x449f2fd99174e1785CF2A1c79E665Fec3dD1DdC6 and filtering out the part of emissions that goes back to the treasury
- Adding CVX that is paid out by the treasury (mostly as voting incentives although all token outflows are included)

I modified the logic in adapters/supply/index.ts as it was throwing an error and also seemed to be missing the caching it looked like it was intended for.
